### PR TITLE
Fix #17 & #18:  Reduce loading time and add a basic console interface

### DIFF
--- a/include/yc20-precalc.h
+++ b/include/yc20-precalc.h
@@ -78,6 +78,12 @@ _yc20_get_sample(dsp *x, float phase, int note, int div)
 void
 yc20_destroy_oscillators(yc20_precalc_osc *osc);
 
+int
+yc20_save_precalc_osc(yc20_precalc_osc *p, const char *fpath);
+
+yc20_precalc_osc *
+yc20_load_precalc_osc(float samplerate, const char *fpath);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lv2.cpp
+++ b/src/lv2.cpp
@@ -40,6 +40,7 @@ ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE.
 #include <lv2/lv2plug.in/ns/ext/urid/urid.h>
 
 #include <foo-yc20.h>
+#include <foo-yc20-os.h>
 #include <yc20-precalc.h>
 
 #ifdef __cplusplus
@@ -83,7 +84,15 @@ static LV2_Handle instantiate_FooYC20 (
 	handle->yc20 = new YC20Processor();
 	handle->yc20->setDSP(tmp);
 
-	getUserData(tmp)->osc = yc20_precalc_oscillators(sample_rate);
+	//Try loading oscillator data from cache file... 
+	std::string fpath=DEFAULT_CONFIG_DIR + "/.precalc_osc.dat";
+	getUserData(tmp)->osc=yc20_load_precalc_osc(sample_rate,fpath.c_str());
+
+	//If not, precalculate and save to cache ...
+	if (!getUserData(tmp)->osc) {
+		getUserData(tmp)->osc = yc20_precalc_oscillators(sample_rate);
+		yc20_save_precalc_osc(getUserData(tmp)->osc,fpath.c_str());
+	}
 
 	return (LV2_Handle)handle;
 }

--- a/src/main-cli.cpp
+++ b/src/main-cli.cpp
@@ -34,6 +34,8 @@ ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <signal.h>
 #include <unistd.h>
+#include <dirent.h>
+#include <string.h>
 
 #include <yc20-jack.h>
 #include <foo-yc20-os.h>
@@ -52,8 +54,7 @@ void exit_cli(int sig)
 	std::cerr << "Exiting" << std::endl;
 }
 
-int main(int argc, char **argv)
-{
+std::string get_version() {
 	std::string version(VERSION_STR);
 	std::string svn_revision("$Revision: 106 $");
 
@@ -61,11 +62,36 @@ int main(int argc, char **argv)
 		version = svn_revision.substr(11, svn_revision.find(" $", 11));
 		version = "svn-" + version;
 	}
-	
 
-#define L << std::endl <<
-	std::cerr << "Foo-YC20 (CLI) " << version 
-	L	"Copyright 2010-2011 Sampo Savolainen (v2@iki.fi). All rights reserved."
+	return version;
+}
+
+void print_usage() {
+	#define L << std::endl <<
+	std::cerr << "Usage: foo-yc20-cli [OPTION] | [PRESET_FILE_PATH]"
+	L ""
+	L	"Run foo-yc20 combo-organ emulator in headless mode. The following options are accepted:"
+	L ""
+	L	"   -h      Display this help and exit"
+	L	"   -l      Display license info and exit"
+	L "" << std::endl;
+	#undef L
+}
+
+void print_command_help() {
+	#define L << std::endl <<
+	std::cerr << "Available Commands:"
+	L	"   + get_presets : Print preset list"
+	L "   + set_preset [PRESET_FILE_PATH] : Load preset from file"
+	L "   + help : Print command help"
+	L "   + exit : Exit"
+	L "" << std::endl;
+	#undef L
+}
+
+void print_license() {
+	#define L << std::endl <<
+	std::cerr << "Copyright 2010-2011 Sampo Savolainen (v2@iki.fi). All rights reserved."
 	L	"Redistribution and use in source and binary forms, with or without modification,"
 	L	"are permitted provided that the following conditions are met:"
 	L	"   1. Redistributions of source code must retain the above copyright notice,"
@@ -85,8 +111,64 @@ int main(int argc, char **argv)
 	L	"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF"
 	L	"LIABILITY, WHETHERIN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE"
 	L	"OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF"
-	L	"ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE." << std::endl;
-#undef L
+	L	"ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE."
+	L "" << std::endl;
+	#undef L
+}
+
+void print_presets() {
+	DIR *dir;
+	struct dirent *ent;
+	std::string dirName(DEFAULT_CONFIG_DIR);
+	if ((dir = opendir (dirName.c_str())) != NULL) {
+		while ((ent = readdir (dir)) != NULL) {
+			if (ent->d_name[0]=='.') continue; 
+			std::cout << ent->d_name << std::endl;
+		}
+		closedir (dir);
+	} else {
+		std::cerr << "Could not open presets directory!" << std::endl;
+	}
+}
+
+void process_command(YC20Jack &processor, char *command) {
+	char arg1[128];
+
+	if (strcmp(command, "get_presets\n") == 0) {
+		print_presets();
+	}
+	else if (sscanf(command, "set_preset %[a-zA-Z0-9_:/-.#]\n", arg1) == 1) {
+		std::string dirName(DEFAULT_CONFIG_DIR);
+		std::string fname(arg1);
+		std::string fpath=dirName + "/" + fname;
+		std::cerr << "Loading preset <" << fpath << ">" << std::endl;
+		processor.loadConfiguration(fpath);
+	}
+	else if (strcmp(command, "help\n") == 0) {
+		print_command_help();
+	}
+	else if (strcmp(command, "exit\n") == 0) {
+		exit_cli(0);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	std::cerr << "Foo-YC20 (CLI) " << get_version() << " (c)Sampo Savolainen 2010" << std::endl << std::endl;
+
+	std::string config_fpath;
+	if (argc > 1) {
+		std::string arg1(argv[1]);
+		if (arg1=="-h") {
+			print_usage();
+			return 0;
+		} else if (arg1=="-l") {
+			print_license();
+			return 0;
+		} else {
+			config_fpath=arg1;
+		}
+	}
 
 	YC20Jack processor;
 	processor.connect();
@@ -98,10 +180,9 @@ int main(int argc, char **argv)
 	processor.setDSP(yc20);
 	getUserData(yc20)->osc = osc;
 
-	if (argc > 1) {
-		std::string conf(argv[1]);
-		std::cerr << "using configuration file '" << conf << "'" << std::endl;
-		processor.loadConfiguration(conf);
+	if (!config_fpath.empty()) {
+		std::cerr << "Using configuration file '" << config_fpath << "'" << std::endl;
+		processor.loadConfiguration(config_fpath);
 	} else {
 		processor.loadConfiguration();
 	}
@@ -110,9 +191,19 @@ int main(int argc, char **argv)
 	run = true;
 	signal(SIGINT, exit_cli);
 
-	while(run) {
-		sleep(100); // ctrl-C interrupts sleep and runs exit_cli() which sets run to false
+	while (run) {
+		char line[128];
+		std::cout << "> ";
+		if (fgets(line, sizeof(line), stdin)) {
+			process_command(processor, line);
+		} else {
+			break;
+		}
 	}
+
+	//while(run) {
+	//	sleep(100); // ctrl-C interrupts sleep and runs exit_cli() which sets run to false
+	//}
 
 	processor.deactivate();
 

--- a/src/main-cli.cpp
+++ b/src/main-cli.cpp
@@ -139,7 +139,7 @@ void process_command(YC20Jack &processor, char *command) {
 	if (strcmp(command, "get_presets\n") == 0) {
 		print_presets();
 	}
-	else if (sscanf(command, "set_preset %[a-zA-Z0-9_:/-.#]\n", arg1) == 1) {
+	else if (sscanf(command, "set_preset %127[a-zA-Z0-9_:.#&%%()+-]\n", arg1) == 1) {
 		std::string dirName(DEFAULT_CONFIG_DIR);
 		std::string fname(arg1);
 		std::string fpath=dirName + "/" + fname;
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 
 	while (run) {
 		char line[128];
-		std::cout << "> ";
+		std::cout << "> " << std::flush;
 		if (fgets(line, sizeof(line), stdin)) {
 			process_command(processor, line);
 		} else {

--- a/src/main-gui.cpp
+++ b/src/main-gui.cpp
@@ -43,6 +43,59 @@ void quit_callback(GtkWidget *widget, gpointer data)
 	gtk_main_quit();
 }
 
+std::string get_version() {
+	std::string version(VERSION_STR);
+	std::string svn_revision("$Revision: 106 $");
+
+	if (version == "") {
+		version = svn_revision.substr(11, svn_revision.find(" $", 11));
+		version = "svn-" + version;
+	}
+
+	return version;
+}
+
+void print_usage() {
+	#define L << std::endl <<
+	std::cerr << "Usage: foo-yc20-cli [OPTION] | [PRESET_FILE_PATH]"
+	L ""
+	L	"Run foo-yc20 combo-organ emulator in headless mode. The following options are accepted:"
+	L ""
+	L	"   -f      Force regeneration of oscillator data cache"
+	L	"   -g      Generate oscillators data cache and exit"
+	L	"   -h      Display this help and exit"
+	L	"   -l      Display license info and exit"
+	L "" << std::endl;
+	#undef L
+}
+
+void print_license() {
+	#define L << std::endl <<
+	std::cerr << "Copyright 2010-2011 Sampo Savolainen (v2@iki.fi). All rights reserved."
+	L	"Redistribution and use in source and binary forms, with or without modification,"
+	L	"are permitted provided that the following conditions are met:"
+	L	"   1. Redistributions of source code must retain the above copyright notice,"
+	L	"      this list of conditions and the following disclaimer."
+	L	"   2. Redistributions in binary form must reproduce the above copyright notice,"
+	L	"      this list of conditions and the following disclaimer in the documentation"
+	L	"      and/or other materials provided with the distribution."
+	L	"   3. Neither the name Foo YC20, its author nor the names of its contributors"
+	L	"      may be used to endorse or promote products derived from this software"
+	L	"      without specific prior written permission."
+	L	"THIS SOFTWARE IS PROVIDED BY SAMPO SAVOLAINEN ``AS IS'' AND ANY EXPRESS OR"
+	L	"IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF"
+	L	"MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT"
+	L	"SHALL SAMPO SAVOLAINEN OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,"
+	L	"INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT"
+	L	"LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR"
+	L	"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF"
+	L	"LIABILITY, WHETHERIN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE"
+	L	"OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF"
+	L	"ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE."
+	L "" << std::endl;
+	#undef L
+}
+
 int main(int argc, char **argv)
 {
 	gtk_init(&argc, &argv);
@@ -52,16 +105,33 @@ int main(int argc, char **argv)
 		g_object_new(GTK_TYPE_OSX_APPLICATION, NULL);
 #endif
 
-	std::string version(VERSION_STR);
-	std::string svn_revision("$Revision: 106 $");
+	//CLI message: program name and version
+	std::cerr << "Foo-YC20 (GUI) " << get_version() << " (c)Sampo Savolainen 2010" << std::endl << std::endl;
 
-	if (version == "") {
-		version = svn_revision.substr(11, svn_revision.find(" $", 11));
-		version = "svn-" + version;
+	//Process command line options
+	int force_precalc_osc=0;
+	int exit_after_precalc_osc=0;
+	std::string config_fpath;
+	if (argc > 1) {
+		std::string arg1(argv[1]);
+		if (arg1=="-h") {
+			print_usage();
+			return 0;
+		} else if (arg1=="-l") {
+			print_license();
+			return 0;
+		} else if (arg1=="-f") {
+			force_precalc_osc=1;
+		} else if (arg1=="-g") {
+			force_precalc_osc=1;
+			exit_after_precalc_osc=1;
+		} else {
+			config_fpath=arg1;
+		}
+		if (config_fpath.empty() and argc > 2) {
+			config_fpath=argv[2];
+		}
 	}
-	
-
-	std::cerr << "Foo-YC20 " << version << " (c)Sampo Savolainen 2010" << std::endl;
 
 	GtkWidget *main_window;
 	YC20UI    *yc20ui;
@@ -87,7 +157,24 @@ int main(int argc, char **argv)
 
 	// Create DSP (& retrieve samplerate)
 	dsp *yc20 = createDSP();
-	yc20_precalc_osc *osc = yc20_precalc_oscillators(processor.getSamplerate());
+
+	yc20_precalc_osc *osc=NULL;
+	//Try loading oscillator data from cache file... 
+	std::string fpath=DEFAULT_CONFIG_DIR + "/.precalc_osc.dat";
+	if (!force_precalc_osc) {
+		osc=yc20_load_precalc_osc(processor.getSamplerate(),fpath.c_str());
+	}
+	//If not, precalculate and save to cache ...
+	if (!osc) {
+		osc = yc20_precalc_oscillators(processor.getSamplerate());
+		yc20_save_precalc_osc(osc,fpath.c_str());
+	}
+	//If only cache regeneration option => exit
+	if (exit_after_precalc_osc) {
+		yc20_destroy_oscillators(osc);
+		return 0;
+	}
+
 	yc20->init(processor.getSamplerate());
 
 	// Connect DSP & processor
@@ -102,12 +189,10 @@ int main(int argc, char **argv)
 
 	gtk_widget_show_all(main_window);
 
-
 	// Load configuration
-	if (argc > 1) {
-		std::string conf(argv[1]);
-		std::cerr << "using configuration file '" << conf << "'" << std::endl;
-		processor.loadConfiguration(conf);
+	if (!config_fpath.empty()) {
+		std::cerr << "Using configuration file '" << config_fpath << "'" << std::endl;
+		processor.loadConfiguration(config_fpath);
 	} else {
 		processor.loadConfiguration();
 	}
@@ -115,10 +200,8 @@ int main(int argc, char **argv)
 	// Set UI state as per current state
 	yc20ui->updateControlsFromState();
 
-
 	// Activate Jack & start
 	processor.activate();
-
 
 	// RUN!
 #ifdef __APPLE__


### PR DESCRIPTION
- Reduce loading time by caching oscillator precalculted data.
- Add a basic console interface that allows listing and loading presets.
- Also, new cli options has been implemented in both cli and gui versions:
  -f    force cache regeneration
  -g    regenerate cache and exit
  -h    help message
  -l    license messages